### PR TITLE
Dynamically setting the copyright year via getFullYear()

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -51,7 +51,7 @@ export default function Footer() {
       </div>
       <div className={footerStyles.copyright}>
         <p>
-          Web Dev Path 2021. All rights reserved.
+          Web Dev Path {new Date().getFullYear()}. All rights reserved.
         </p>
       </div>
     </footer>


### PR DESCRIPTION
|                        Web Dev Path                      |
| :-----------------------------------------------------------: |
| [**52**](https://github.com/MarianaSouza/web-dev-path/issues/52) |

#### What is this change?
I am replacing the hardcoded copyright year in the footer to a dynamic year obtained from getFullYear().

#### Were there any complications while making this change?
No

#### How did you verify this change?
Locally

#### When should this be merged?
After being approved.
