### PR TITLE
refactor: Replace mailto button links with contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - CardsContainers
   - NewsletterSubscribe
   - Hero
-- Removed Styled Components dependency  
+- Removed Styled Components dependency
 - Extracted :root from themes.scss to globals.scss
 - Updated ContactUsForm's checkbox wrapper from div to label to enhance its accessibility
 - Updated SearchInput width to 100% for better styling
@@ -209,3 +209,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed active state bug on the navigation.
 - Integrate Mailchimp Marketing API instead of react-mailchimp-subscribe dependency.
 - Removed unused props from Hero layout component
+- Replace mailto:hello@webdevpath.co button links with /contact

--- a/components/ContactUs/ContactUsForm/index.js
+++ b/components/ContactUs/ContactUsForm/index.js
@@ -4,7 +4,7 @@ import RevealContentContainer from '@/components/containers/RevealContentContain
 import { SubmitButton } from '@/components/buttons/SubmitButton';
 import styles from './ContactUsForm.module.scss';
 
-function ContactUsForm({ setResponseMessage, getReCaptchaToken }) {
+function ContactUsForm({ subject, setResponseMessage, getReCaptchaToken }) {
   const {
     register,
     handleSubmit,
@@ -14,7 +14,7 @@ function ContactUsForm({ setResponseMessage, getReCaptchaToken }) {
     defaultValues: {
       Name: '',
       Email: '',
-      Subject: '',
+      Subject: subject || '',
       Message: '',
     },
   });

--- a/components/ContactUs/index.js
+++ b/components/ContactUs/index.js
@@ -2,9 +2,11 @@ import React from 'react';
 import ReCapchaWrapper from '../Recapcha';
 import ContactUsForm from '@/components/ContactUs/ContactUsForm';
 
-const ContactUs = ({ setMsg }) => {
+const ContactUs = ({ subject, setMsg }) => {
   return (
-    <ReCapchaWrapper children={<ContactUsForm setResponseMessage={setMsg} />} />
+    <ReCapchaWrapper
+      children={<ContactUsForm subject={subject} setResponseMessage={setMsg} />}
+    />
   );
 };
 

--- a/components/buttons/ButtonLink/index.js
+++ b/components/buttons/ButtonLink/index.js
@@ -1,4 +1,5 @@
 import styles from './ButtonLink.module.scss';
+import Link from 'next/link';
 import { combineClasses } from '@/utils/classnames';
 
 export default function ButtonLink({
@@ -8,14 +9,18 @@ export default function ButtonLink({
   openNewTab,
 }) {
   const buttonClass = combineClasses(styles.buttonLink, customBtnClass, styles);
-  return (
+  return openNewTab ? (
     <a
       href={link}
       className={buttonClass}
-      target={openNewTab ? '_blank' : undefined}
+      target='_blank'
       rel='noopener noreferrer'
     >
       {children}
     </a>
+  ) : (
+    <Link href={link} className={buttonClass}>
+      {children}
+    </Link>
   );
 }

--- a/components/layout/Nav/index.js
+++ b/components/layout/Nav/index.js
@@ -101,8 +101,8 @@ export default function Nav() {
                 );
               })}
               <li className={styles.item}>
-                <a
-                  href='mailto:hello@webdevpath.co?subject=Project collaborator application'
+                <Link
+                  href='/contact?subject=Project collaborator application'
                   className={`
                     ${active ? styles.active : ''} 
                     ${isSticky ? styles.buttonSticky : styles.button}
@@ -110,7 +110,7 @@ export default function Nav() {
                   title='Join us'
                 >
                   Join us
-                </a>
+                </Link>
               </li>
             </ul>
             <button

--- a/components/layout/Nav/index.js
+++ b/components/layout/Nav/index.js
@@ -102,7 +102,7 @@ export default function Nav() {
               })}
               <li className={styles.item}>
                 <Link
-                  href='/contact?subject=Project collaborator application'
+                  href='/contact?subject=Application: I want to join the project'
                   className={`
                     ${active ? styles.active : ''} 
                     ${isSticky ? styles.buttonSticky : styles.button}

--- a/components/layout/Nav/index.js
+++ b/components/layout/Nav/index.js
@@ -90,13 +90,13 @@ export default function Nav() {
               {linksNav.map(({ text, href, id }) => {
                 return (
                   <li className={styles.item} key={id}>
-                    <a
+                    <Link
                       href={href}
                       className={`${styles.link} ${router.pathname === href ? styles.current : ''}`}
                       title={text}
                     >
                       {text}
-                    </a>
+                    </Link>
                   </li>
                 );
               })}

--- a/pages/about.js
+++ b/pages/about.js
@@ -207,7 +207,7 @@ export default function AboutUs() {
           image='/images/svg/slash.svg'
           altTag=''
           customInnerClass='get-started'
-          link='mailto:hello@webdevpath.co'
+          link='/contact'
           linkText='Ping us'
           customBtnClass='inverted-grey'
         />

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,13 +1,25 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import ContactUsFormSubscribe from '@/components/ContactUs';
-import ContactUsCards from '@/components/ContactUs/ContactUsCards';
-import styles from '@/styles/pages/contact.module.scss';
 import Bracket from '@/components/decorations/Bracket';
 import bracketStyles from '@/components/decorations/Bracket/Bracket.module.scss';
+import ContactUsCards from '@/components/ContactUs/ContactUsCards';
+import ContactUsFormSubscribe from '@/components/ContactUs';
+import styles from '@/styles/pages/contact.module.scss';
 export default function ContactUs() {
-  const [message, setMessage] = useState([]);
+  const subjectFilled = useRef(false);
   const searchParams = useSearchParams();
+  const subjectParam = searchParams.get('subject');
+  const [param, setParam] = useState(subjectParam || '');
+  const [message, setMessage] = useState([]);
+
+  function updateSubject(state, value) {
+    subjectFilled.current = state;
+    setParam(value);
+  }
+
+  subjectParam && !subjectFilled.current && updateSubject(true, subjectParam);
+  !subjectParam && subjectFilled.current && updateSubject(false, '');
+
   return (
     <>
       <div className={styles.contactUsContainer}>
@@ -15,7 +27,8 @@ export default function ContactUs() {
           <div className={styles.formAndDecorations}>
             <Bracket className={bracketStyles.yellowBracket} />
             <ContactUsFormSubscribe
-              subject={searchParams.get('subject')}
+              key={param}
+              subject={param}
               setMsg={setMessage}
             />
             <img

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import ContactUsFormSubscribe from '@/components/ContactUs';
 import ContactUsCards from '@/components/ContactUs/ContactUsCards';
 import styles from '@/styles/pages/contact.module.scss';
@@ -6,14 +7,17 @@ import Bracket from '@/components/decorations/Bracket';
 import bracketStyles from '@/components/decorations/Bracket/Bracket.module.scss';
 export default function ContactUs() {
   const [message, setMessage] = useState([]);
-
+  const searchParams = useSearchParams();
   return (
     <>
       <div className={styles.contactUsContainer}>
         <div className={styles.formWrapper}>
           <div className={styles.formAndDecorations}>
             <Bracket className={bracketStyles.yellowBracket} />
-            <ContactUsFormSubscribe setMsg={setMessage} />
+            <ContactUsFormSubscribe
+              subject={searchParams.get('subject')}
+              setMsg={setMessage}
+            />
             <img
               className={styles.yellowColon}
               src='/images/svg/yellow-colon.svg'


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |
| [**295**](https://github.com/Web-Dev-Path/web-dev-path/issues/295) |
|  closes #295 |

#### Have you updated the CHANGELOG.md file? If not, please do it.

Yes

#### What is this change?

- Replace `mailto:hello@webdevpath.co` button links with `/contact`.
- Prevent full-page reloads on clicking internal links to enhance user experience.

#### Were there any complications while making this change?

No

#### How to replicate the issue?

Clicking the main branch’s “Join us” (navbar) or “Ping us” (about page) buttons would navigate to `mailto:hello@webdevpath.co`.

<img width="757" height="372" alt="Image" src="https://github.com/user-attachments/assets/9f23d7b4-c5d7-4904-9189-fef387806998" />

<img width="757" height="377" alt="Image" src="https://github.com/user-attachments/assets/2494222c-4848-4e39-a97e-d0e2aa740bf9" />

#### If necessary, please describe how to test the new feature or fix.

Clicking the PR branch’s “Join us” (navbar) or “Ping us” (about page) buttons would navigate to `/contact` without a full-page reload.

<img width="1920" height="1080" alt="navbar-join-us-btn-wdp" src="https://github.com/user-attachments/assets/6776c76e-e179-4fad-b2c0-4161dbb16bdc" />

<img width="1920" height="1080" alt="about-page-ping-us-btn-wdp" src="https://github.com/user-attachments/assets/b30471d2-dfef-4574-9751-f5604de435c3" />

#### When should this be merged?

After three approved reviews.